### PR TITLE
Add AI poker tournament with websocket broadcasting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# ArenaAI
+# ArenaAI Poker Tournament
+
+This repository hosts a simple AI-vs-AI poker tournament with a leaderboard and
+basic websocket broadcasting of game events.
+
+## Running
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the tournament and broadcaster (plays 20 rounds by default):
+
+```bash
+python main.py
+```
+
+You can customize the number of rounds by importing `run_tournament` and
+passing a value:
+
+```bash
+python - <<'PY'
+from main import run_tournament
+run_tournament(5)
+PY
+```
+
+A websocket server will be available on `ws://localhost:8765` streaming round
+updates and leaderboard standings.
+
+## Testing
+
+```bash
+python -m pytest
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,27 @@
+import asyncio
+import contextlib
+
+from poker.broadcast import WebsocketBroadcaster
+from poker.player import Player
+from poker.tournament import Tournament
+
+
+def run_tournament(rounds: int = 20) -> None:
+    players = [Player(f"AI{i}") for i in range(1, 5)]
+    broadcaster = WebsocketBroadcaster()
+    tournament = Tournament(players)
+
+    async def runner() -> None:
+        server_task = asyncio.create_task(broadcaster.run())
+        try:
+            await asyncio.to_thread(tournament.play, rounds, broadcaster)
+        finally:
+            server_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await server_task
+
+    asyncio.run(runner())
+
+
+if __name__ == "__main__":
+    run_tournament()

--- a/poker/broadcast.py
+++ b/poker/broadcast.py
@@ -1,0 +1,36 @@
+import asyncio
+import json
+from typing import Set
+
+import websockets
+
+from .tournament import Broadcaster
+
+
+class WebsocketBroadcaster(Broadcaster):
+    def __init__(self, host: str = "0.0.0.0", port: int = 8765) -> None:
+        self.host = host
+        self.port = port
+        self.clients: Set[websockets.WebSocketServerProtocol] = set()
+        self.queue: "asyncio.Queue[dict]" = asyncio.Queue()
+
+    async def _client_handler(self, websocket: websockets.WebSocketServerProtocol) -> None:
+        self.clients.add(websocket)
+        try:
+            await websocket.wait_closed()
+        finally:
+            self.clients.remove(websocket)
+
+    async def _broadcaster(self) -> None:
+        while True:
+            data = await self.queue.get()
+            if self.clients:
+                message = json.dumps(data)
+                await asyncio.gather(*(client.send(message) for client in self.clients))
+
+    def publish(self, data: dict) -> None:
+        self.queue.put_nowait(data)
+
+    async def run(self) -> None:
+        async with websockets.serve(self._client_handler, self.host, self.port):
+            await self._broadcaster()

--- a/poker/card.py
+++ b/poker/card.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+import random
+from typing import List
+
+SUITS = ['Hearts', 'Diamonds', 'Clubs', 'Spades']
+RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K', 'A']
+
+@dataclass(frozen=True)
+class Card:
+    rank: str
+    suit: str
+
+    def __str__(self) -> str:  # pragma: no cover - simple repr
+        return f"{self.rank}{self.suit[0]}"
+
+class Deck:
+    """Standard 52 card deck."""
+    def __init__(self) -> None:
+        self.cards: List[Card] = [Card(rank, suit) for suit in SUITS for rank in RANKS]
+        self.shuffle()
+
+    def shuffle(self) -> None:
+        random.shuffle(self.cards)
+
+    def deal(self, n: int) -> List[Card]:
+        return [self.cards.pop() for _ in range(n)]

--- a/poker/game.py
+++ b/poker/game.py
@@ -1,0 +1,35 @@
+from typing import List, Tuple
+
+from .card import Deck
+from .hand import evaluate
+from .player import Player
+
+
+class Game:
+    def __init__(self, players: List[Player]) -> None:
+        self.players = players
+
+    def play_round(self, ante: int = 10) -> Tuple[List[str], List[Player], int]:
+        deck = Deck()
+        pot = 0
+        active: List[Player] = []
+        for player in self.players:
+            if player.chips < ante:
+                player.active = False
+                continue
+            player.chips -= ante
+            pot += ante
+            player.hand = deck.deal(2)
+            if player.decide([]):
+                active.append(player)
+        community = deck.deal(5)
+        if not active:
+            return [str(c) for c in community], [], pot
+        scores = [(evaluate(p.hand + community), p) for p in active]
+        scores.sort(reverse=True)
+        best = scores[0][0]
+        winners = [p for score, p in scores if score == best]
+        share = pot // len(winners)
+        for w in winners:
+            w.chips += share
+        return [str(c) for c in community], winners, pot

--- a/poker/hand.py
+++ b/poker/hand.py
@@ -1,0 +1,57 @@
+from collections import Counter
+from itertools import combinations
+from typing import List, Tuple
+
+from .card import Card, RANKS
+
+RANK_VALUE = {r: i for i, r in enumerate(RANKS, start=2)}
+
+HandScore = Tuple[int, List[int]]
+
+
+def _evaluate_five(cards: List[Card]) -> HandScore:
+    ranks = sorted([RANK_VALUE[c.rank] for c in cards], reverse=True)
+    counts = Counter(ranks)
+    count_items = sorted(counts.items(), key=lambda x: (x[1], x[0]), reverse=True)
+    is_flush = len({c.suit for c in cards}) == 1
+    is_straight = False
+    if len(counts) == 5:
+        high, low = max(ranks), min(ranks)
+        if high - low == 4:
+            is_straight = True
+        elif set(ranks) == {14, 5, 4, 3, 2}:  # wheel straight
+            is_straight = True
+            ranks = [5, 4, 3, 2, 1]
+    if is_straight and is_flush:
+        return (8, ranks)
+    if count_items[0][1] == 4:
+        kicker = [c for c in ranks if c != count_items[0][0]][0]
+        return (7, [count_items[0][0], kicker])
+    if count_items[0][1] == 3 and count_items[1][1] == 2:
+        return (6, [count_items[0][0], count_items[1][0]])
+    if is_flush:
+        return (5, ranks)
+    if is_straight:
+        return (4, ranks)
+    if count_items[0][1] == 3:
+        kickers = [x for x in ranks if x != count_items[0][0]]
+        return (3, [count_items[0][0]] + kickers)
+    if count_items[0][1] == 2 and count_items[1][1] == 2:
+        pair_ranks = sorted([count_items[0][0], count_items[1][0]], reverse=True)
+        kicker = [c for c in ranks if c not in pair_ranks][0]
+        return (2, pair_ranks + [kicker])
+    if count_items[0][1] == 2:
+        pair_rank = count_items[0][0]
+        kickers = [c for c in ranks if c != pair_rank]
+        return (1, [pair_rank] + kickers)
+    return (0, ranks)
+
+
+def evaluate(cards: List[Card]) -> HandScore:
+    """Return the best hand score for up to 7 cards."""
+    best: HandScore = (-1, [])
+    for combo in combinations(cards, 5):
+        score = _evaluate_five(list(combo))
+        if score > best:
+            best = score
+    return best

--- a/poker/player.py
+++ b/poker/player.py
@@ -1,0 +1,22 @@
+from typing import List
+
+from .card import Card
+
+
+class Player:
+    def __init__(self, name: str, chips: int = 100) -> None:
+        self.name = name
+        self.chips = chips
+        self.hand: List[Card] = []
+        self.active = True
+
+    def reset(self) -> None:
+        self.hand = []
+        self.active = True
+
+    def decide(self, community: List[Card]) -> bool:
+        """Return True to stay in hand, False to fold."""
+        if not community:
+            high = {'A', 'K', 'Q', 'J', 'T'}
+            return any(card.rank in high for card in self.hand)
+        return True

--- a/poker/tournament.py
+++ b/poker/tournament.py
@@ -1,0 +1,33 @@
+import time
+from typing import List, Optional
+
+from .game import Game
+from .player import Player
+
+
+class Tournament:
+    def __init__(self, players: List[Player]) -> None:
+        self.players = players
+        self.game = Game(players)
+
+    def leaderboard(self) -> List[Player]:
+        return sorted(self.players, key=lambda p: p.chips, reverse=True)
+
+    def play(self, rounds: int, broadcaster: Optional["Broadcaster"] = None) -> None:
+        for rnd in range(1, rounds + 1):
+            community, winners, pot = self.game.play_round()
+            if broadcaster:
+                data = {
+                    "round": rnd,
+                    "community": community,
+                    "winners": [w.name for w in winners],
+                    "pot": pot,
+                    "leaderboard": [(p.name, p.chips) for p in self.leaderboard()],
+                }
+                broadcaster.publish(data)
+            time.sleep(1)
+
+
+class Broadcaster:
+    def publish(self, data: dict) -> None:  # pragma: no cover - interface
+        raise NotImplementedError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+websockets>=10.0

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -1,0 +1,14 @@
+import unittest
+
+from poker.card import Deck
+
+
+class DeckTest(unittest.TestCase):
+    def test_deck_unique(self) -> None:
+        deck = Deck()
+        self.assertEqual(len(deck.cards), 52)
+        self.assertEqual(len({str(c) for c in deck.cards}), 52)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -1,0 +1,18 @@
+import unittest
+
+from poker.player import Player
+from poker.tournament import Tournament
+
+
+class TournamentTest(unittest.TestCase):
+    def test_leaderboard(self) -> None:
+        players = [Player("A"), Player("B")]
+        t = Tournament(players)
+        t.play(1)
+        lb = t.leaderboard()
+        self.assertEqual(len(lb), 2)
+        self.assertGreaterEqual(lb[0].chips, lb[1].chips)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow tournament runner to stop cleanly by cancelling the websocket broadcaster
- document optional round count and switch test instructions to `pytest`

## Testing
- `python -m pytest`
- `python - <<'PY'
from main import run_tournament
run_tournament(2)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689972cca8a4832ab6f0112e5fa4aefa